### PR TITLE
fix: 补充 marketplace.json 缺少的 owner 和 plugins 字段

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,8 @@
 {
   "shortname": "uv-python",
   "name": "uv-python",
+  "owner": "ShiWenber",
   "description": "使用 uv 进行 Python 项目开发与管理",
+  "plugins": ["uv-python"],
   "skills": ["uv-python"]
 }


### PR DESCRIPTION
## 修复内容

在 .claude-plugin/marketplace.json 中添加：
- owner: "ShiWenber"
- plugins: ["uv-python"]

## 验证

修复后 marketplace.json 内容：
